### PR TITLE
Adding some functionalities (basic filtering, timeline checkline, running tests optimization, global coverage calculation)

### DIFF
--- a/src/pages/TestCoverageTool.page
+++ b/src/pages/TestCoverageTool.page
@@ -7,7 +7,7 @@
       <title>Salesforce Test Coverage</title>
       <style>
           .timeline{
-          	margin-top : 1rem;
+          	margin-top : 1rem!important;
           }
         .pace {
         -webkit-pointer-events: none;
@@ -246,7 +246,35 @@
             border-top-left-radius: 0;
             border-bottom-left-radius: 0
         }
-
+        /* Order */
+        .slds-is-sortable.sort-desc:before {
+            position: absolute;
+            content: '';
+            display: block;
+            right: 0.5rem;
+            width: 0;
+            height: 0;
+            border-left: 3px solid transparent;
+            border-right: 3px solid transparent;
+          	border-bottom: 5px solid #061c3f;
+          	top: calc((1.75rem / 2) - 6px);
+        }
+        .slds-is-sortable.sort-asc:after {
+            position: absolute;
+            content: '';
+            display: block;
+            right: 0.5rem;
+            width: 0;
+            height: 0;
+            border-left: 3px solid transparent;
+            border-right: 3px solid transparent;
+            border-top: 5px solid #061c3f;
+            bottom: calc((1.75rem / 2) - 6px);
+        }
+        /*override icon check color */
+        .slds-icon-utility-check{
+          fill:#4aafad!important;
+        }
       </style>
       <!--link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.min.css"></link-->
       <apex:stylesheet value="{!URLFOR($Asset.SLDS, 'assets/styles/salesforce-lightning-design-system-vf.css')}" />
@@ -256,14 +284,17 @@
       <!--link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/ng-table/0.8.3/ng-table.min.css"></link-->
       
       <script src="https://cdnjs.cloudflare.com/ajax/libs/ng-table/0.8.3/ng-table.min.js"></script>
-      <script src="https://cdnjs.cloudflare.com/ajax/libs/jsforce/1.5.0/jsforce.min.js" async="async"></script>
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/jsforce/1.8.0/jsforce.min.js" async="async"></script>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/1.0.2/Chart.min.js" async="async"></script>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.0.3/jquery.min.js" async="async"></script>
       <script data-run-script="">
         var data = [];
+      	var orgCoverage;
+        var refreshData;
+          
         var app = angular.module("angularTable", ['ngTable']);
- 
-        app.controller("ctrlRead", function($scope, $filter,ngTableParams){
+
+        app.controller("ctrlRead", function($scope, $filter,ngTableParams ){
             
             //table description
             $scope.columns = [
@@ -293,7 +324,6 @@
                 		$scope.data = params.filter() ? $filter('filter')($scope.data, params.filter()) : $scope.data;
                 		params.total($scope.data.length);
                         $scope.data = $scope.data.slice((params.page() - 1) * params.count(), params.page() * params.count());
-                        console.log($scope.data)
                 		$defer.resolve($scope.data);
                     }
               }, );
@@ -301,6 +331,11 @@
             $scope.displayTable = function() {
                 $scope.tableParams.reload();
             };
+                
+            $scope.changeFilter = function(){
+                localStorage.filter = this.name;               
+                refreshData();
+            }
         });
             ///END ANGULAR///
       </script>
@@ -314,41 +349,79 @@
         </div>
       </div>
       <div id="wct-content" ng-app="angularTable" class="slds-scope">
-        <div class="slds-page-header" role="banner">
-          <div class="slds-media">
-            <div class="slds-media__figure">
-              <svg aria-hidden="true" class="slds-icon slds-icon--large slds-icon-standard-solution">
-                <use xlink:href="{!URLFOR($Asset.SLDS, 'assets/icons/standard-sprite/svg/symbols.svg#solution')}" ></use>
-              </svg>
-            </div>
-            <div class="slds-media__body">
-              <p class="slds-text-heading--label">Test Coverage module</p>
-              <div class="slds-grid">
-                <h1 class="slds-page-header__title slds-m-right--small slds-truncate slds-align-middle" title="Salesforce Online Test Coverage tool.">Salesforce Online Test Coverage tool.</h1>
-                <div class="slds-col slds-shrink-none">
-                  <button class="slds-button slds-button--neutral slds-text-selected" aria-live="assertive" id="reset-coverage">
-                    <span class="slds-text-selected">
-                      <svg aria-hidden="true" class="slds-button__icon--stateful slds-button__icon--left">
-                        <use xlink:href="{!URLFOR($Asset.SLDS, 'assets/icons/utility-sprite/svg/symbols.svg#check')}"></use>
-                      </svg>Reset Coverage</span>
-                  </button>
-                </div>
-              </div>
-            </div>
+          <div class="slds-page-header" role="banner">
+              <div class="slds-media">
+                  <div class="slds-media__figure">
+                      <svg aria-hidden="true" class="slds-icon slds-icon--large slds-icon-standard-solution">
+                          <use xlink:href="{!URLFOR($Asset.SLDS, 'assets/icons/standard-sprite/svg/symbols.svg#solution')}" ></use>
+                      </svg>
+                  </div>
+                  <div class="slds-media__body">
+                      <p class="slds-text-heading--label">Test Coverage module</p>
+                      <div class="slds-grid">
+                          <h1 class="slds-page-header__title slds-m-right--small slds-truncate slds-align-middle" title="Salesforce Online Test Coverage tool.">Salesforce Online Test Coverage tool.</h1>
+                          <div class="slds-col slds-shrink-none">
+                              <button class="slds-button slds-button--neutral slds-text-selected" aria-live="assertive" id="reset-coverage">
+                                  <span class="slds-text-selected">
+                                      <svg aria-hidden="true" class="slds-button__icon--stateful slds-button__icon--left">
+                                          <use xlink:href="{!URLFOR($Asset.SLDS, 'assets/icons/utility-sprite/svg/symbols.svg#check')}"></use>
+                                      </svg>Reset Coverage</span>
+                              </button>
+                          </div>
+                      </div>
+                  </div>
+                  <fieldset class="slds-form-element">
+                      <legend class="slds-form-element__legend slds-form-element__label">Test Classes</legend>
+                      <div class="slds-form-element__control">
+                          <span class="slds-radio">
+                              <input type="radio" id="radio-1" name="options" value="my"/>
+                              <label class="slds-radio__label" for="radio-1">
+                                  <span class="slds-radio_faux"></span>
+                                  <span class="slds-form-element__label">My Namespace</span>
+                              </label>
+                          </span>
+                          <span class="slds-radio">
+                              <input type="radio" id="radio-2" name="options" value="all"/>
+                              <label class="slds-radio__label" for="radio-2">
+                                  <span class="slds-radio_faux"></span>
+                                  <span class="slds-form-element__label">All Namespaces</span>
+                              </label>
+                          </span>
+                      </div>
+                  </fieldset>
           </div>
         </div>
 
         <div class="slds-grid slds-wrap slds-grid--pull-padded">
           <div class="slds-col--padded  slds-size--1-of-4 slds-container--center slds-container--small">
             <canvas id="myChart" width="200" height="200"></canvas>
-            <h4>Global Coverage</h4>
+            <h4 id="orgCov">Global Coverage:{{estimatedOrgCoverage}}%</h4>
             <span class="text-muted">Keep up the good work...</span>
+              <div id="LoadingvfDIV" class="slds-spinner_container" style="display:none;position:relative;float:right;">
+                  <div class="slds-spinner slds-spinner_medium slds-spinner_brand" aria-hidden="false" role="alert">
+                      <div class="slds-spinner__dot-a"></div>
+                      <div class="slds-spinner__dot-b"></div>
+                  </div>
+              </div>
               <div class="slds-align-middle">
                   <ul class="timeline">
                   </ul>
               </div>
           </div>
-          <div class="slds-col--padded  slds-size--3-of-4" id="CovTable" ng-controller="ctrlRead">
+          <div class="slds-col--padded slds-size--3-of-4" id="CovTable" ng-controller="ctrlRead">
+              <div class="slds-grid">
+                  <div class="slds-col slds-size--3-of-4">
+                      <div class="slds-form-element slds-m-bottom_medium">
+                          <label class="slds-form-element__label" for="text-input-id-1">Custom filter</label>
+                          <div class="slds-form-element__control">
+                              <input type="text" id="customFilter" class="slds-input" ng-model='name' ng-blur='changeFilter()'/>
+                          </div>
+                      </div>
+                  </div>
+                  <div class="slds-col slds-size--1-of-4 slds-m-top_x-large">
+                      <div class="slds-text-heading_medium slds-text-align_right slds-m-bottom_medium">Apex classes:{{ tableParams.total() }}</div>
+                  </div>
+              </div>
             <table class="slds-table slds-table--bordered table" ng-table="tableParams" show-filter="true">
                 <thead>
                     <tr class="slds-text-heading--label">
@@ -380,6 +453,7 @@
  
         window.onload = function(){
           jQuery.noConflict();
+
           var conn = new jsforce.Connection({ accessToken: '{!$Api.Session_Id}', proxyUrl: '/services/proxy',maxRequest : '10000'});
           conn.metadata.pollTimeout= 240000;
           var testClasses = [];
@@ -404,7 +478,19 @@
             jQuery('#loading').hide();
             jQuery('#reset-coverage').removeAttr('disabled');
           }
- 
+ 		  
+          var addChecked = function(content){
+              var p = document.getElementById(content.replace(/ /g,'_'));
+              var svg = document.createElement('svg');
+              svg.className = 'slds-icon slds-icon-utility-check slds-icon_x-small slds-m-left_x-small';
+              svg.setAttribute('aria-hidden',true);
+              var use = document.createElement('use');
+              use.className = 'slds-icon slds-icon-utility-check';
+              use.setAttribute('xlink:href',"{!URLFOR($Asset.SLDS, '/assets/icons/utility-sprite/svg/symbols.svg#check')}");
+              svg.appendChild(use);
+              p.appendChild(svg);
+              jQuery(".timeline").html(jQuery(".timeline").html());
+          }
           var createTimelineElement = function(content) {
             var frag = document.createDocumentFragment();
             var ul = document.getElementsByClassName('timeline')[0];
@@ -433,6 +519,7 @@
             var p = document.createElement('p');
             p.className = 'slds-tile__title slds-truncate';
             p.innerText = content;
+            p.setAttribute('id',content.replace(/ /g,'_'));
             div31.appendChild(p);
             div21.appendChild(div31);
             div11.appendChild(div21);
@@ -448,53 +535,72 @@
  
             jQuery(".timeline").html(jQuery(".timeline").html());
           }
- 
- 
+
           var sortClassPriority = function(a, b) {
-          return a.Priority > b.Priority ? -1 : a.Priority < b.Priority ? 1 : 0;
+          	return a.Priority > b.Priority ? -1 : a.Priority < b.Priority ? 1 : 0;
           }
  
           var calculatePriority = function(numLinesCov, numLinesUncov) {
-          return parseFloat((numLinesUncov*(1 + 0.7-(numLinesCov/(numLinesCov+numLinesUncov)))).toFixed(2));
+          	return parseFloat((numLinesUncov*(1 + 0.7-(numLinesCov/(numLinesCov+numLinesUncov)))).toFixed(2));
           }
  
           var calculateCov = function(numLinesCov, numLinesUncov) {
-          return parseFloat(numLinesCov+numLinesUncov != 0 ? ((numLinesCov*100)/(numLinesCov+numLinesUncov)).toFixed(2) : 0.00);
+          	return parseFloat(numLinesCov+numLinesUncov != 0 ? ((numLinesCov*100)/(numLinesCov+numLinesUncov)).toFixed(2) : 0.00);
           }
  
-          var calculateGlobalCoverage = function(data){
-          var numlinesUncovered = 0;
-          var numLinesCovered = 0;
-          for(var i=0; i<data.length; i++) {
-            numlinesUncovered += data[i].NumLinesUncovered;
-            numLinesCovered += data[i].NumLinesCovered;
+          var getOrgCoverage = function(){
+            return new Promise(function(resolve,reject){
+              conn.tooling.query("SELECT PercentCovered FROM ApexOrgWideCoverage" , function(error, result) {
+                  if (error) {
+                      reject(error);
+                      return;
+                  }
+                  orgCoverage = 0;
+                  for(var index in result.records) {
+                      orgCoverage = result.records[index].PercentCovered;
+                  }
+                  angular.element(document.getElementById('orgCov')).scope().estimatedOrgCoverage = orgCoverage;
+                  resolve();
+               });
+             })
           }
-          return calculateCov(numLinesCovered, numlinesUncovered);
+          
+          var calculateGlobalCoverage = function(data){
+              var numlinesUncovered = 0;
+              var numLinesCovered = 0;
+              for(var i=0; i<data.length; i++) {
+                numlinesUncovered += data[i].NumLinesUncovered;
+                numLinesCovered += data[i].NumLinesCovered;
+              }
+              return calculateCov(numLinesCovered, numlinesUncovered);
           }
  
           var changeCoverageColor = function(orgCov) {
-          var className = (orgCov < 60)
-            ? 'bg-danger' // Red
-            : (orgCov >= 60 && orgCov < 75)
-              ? 'bg-warning' // Yellow
-              : 'bg-success'; // Green
-          jQuery('#info')[0].className = jQuery('#info')[0].className.replace(/\bbg.*?\b/g, '');
-          jQuery('#info').addClass(className);
+              var className = (orgCov < 60)
+                ? 'bg-danger' // Red
+                : (orgCov >= 60 && orgCov < 75)
+                  ? 'bg-warning' // Yellow
+                  : 'bg-success'; // Green
+              jQuery('#info')[0].className = jQuery('#info')[0].className.replace(/\bbg.*?\b/g, '');
+              jQuery('#info').addClass(className);
           }
  
+          var toogleLoading= function(){
+          	jQuery("#LoadingvfDIV").toggle();
+          }
           // START DELETE CODE COVERAGE
- 
           var deleteTestResult = function(){
-            createTimelineElement('Delete ApexTestResult')
+            createTimelineElement('Delete ApexTestResult');
             return new Promise(function(resolve,reject){
               window.open("/07M?ClearAllData=1", "_blank");
               jQuery(".timeline").html(jQuery(".timeline").html());
+              addChecked('Delete ApexTestResult');
               resolve();
             })
           }
  
           var selectApexCodeCoverage = function() {
-            createTimelineElement('Fetching ApexCodeCoverage')
+            createTimelineElement('Fetching ApexCodeCoverage');
             return new Promise(function(resolve,reject){
               conn.tooling.query('select id from ApexCodeCoverage'
             , function(error, result) {
@@ -502,6 +608,7 @@
                   reject(error);
                   return;
                 }
+                addChecked('Fetching ApexCodeCoverage');
                 var ids = [];
                 for(var i in result.records) {
                   ids.push(result.records[i].Id);
@@ -513,7 +620,7 @@
           }
  
           var deleteApexCodeCoverage = function(ids) {
-            createTimelineElement('Deleting ApexCodeCoverage')
+            createTimelineElement('Deleting ApexCodeCoverage');
             return new Promise(function(resolve,reject){
               if(ids.length > 0) {
                 conn.tooling.sobject('ApexCodeCoverage').delete(ids
@@ -522,19 +629,20 @@
                     reject(error);
                     return;
                   }
+                  addChecked('Deleting ApexCodeCoverage');
                   resolve();
                   return;
                   //deleteApexCodeCoverageAggregate();
                 });
               } else {
+                addChecked('Deleting ApexCodeCoverage');
                 resolve();
               }
             });
           }
  
- 
           var selectApexCodeCoverageAggregate = function() {
-            createTimelineElement('Fetching ApexCodeCoverageAggregate')
+            createTimelineElement('Fetching ApexCodeCoverageAggregate');
             return new Promise(function(resolve,reject){
               conn.tooling.query('select id from ApexCodeCoverageAggregate'
             , function(error, result) {
@@ -542,6 +650,7 @@
                   reject(error);
                   return;
                 }
+                addChecked('Fetching ApexCodeCoverageAggregate');
                 var ids = [];
                 for(var i in result.records) {
                   ids.push(result.records[i].Id);
@@ -562,10 +671,12 @@
                     reject(error);
                     return;
                   }
+                  addChecked('Deleting ApexCodeCoverageAggregate');
                   resolve();
                   //createContainer();
                 });
               } else {
+                addChecked('Deleting ApexCodeCoverageAggregate');
                 resolve();
               }
             })
@@ -573,13 +684,14 @@
  
           ////////START METHOD COMPILE CLASSES////////
           var createContainer = function() {
-            createTimelineElement('Create MetaDataContainer')
+            createTimelineElement('Create MetaDataContainer');
             return new Promise(function(resolve,reject){
               conn.tooling.sobject('MetadataContainer').create({name:'AwsomeMDC'+new Date().getTime()}, function(err, result){
-                if(err){
+                  if(err){
                   reject(err);
                   return;
                 }
+                addChecked('Create MetaDataContainer');
                 resolve(result.id);
                 //getClassNames(createApexClassMember);
               });
@@ -588,7 +700,7 @@
  
           ///Get Class Names///
           var getClassNames = function() {
-            createTimelineElement('Get Classes')
+            createTimelineElement('Get Classes');
             return new Promise(function(resolve,reject){
               var MetadataArray = [];
               conn.tooling.query("select id, Name, Body from ApexClass WHERE NamespacePrefix = null")
@@ -599,6 +711,7 @@
                 testClasses = MetadataArray.filter(function(el) {
                     return el.Name.toLowerCase().includes('test');
                 });
+                addChecked('Get Classes');
                 resolve({'classNames' : MetadataArray});
               })
               .on("error",function(err){reject(err);})
@@ -609,7 +722,7 @@
  
           //Create member
           var createApexClassMember = function(options) {
-            createTimelineElement('Create ApexClassMembers')
+            createTimelineElement('Create ApexClassMembers');
             return new Promise(function(resolve,reject){
               var apexClassMemberArray = options[4].classNames.map(function(meta) {
                 return {Body: meta.Body,
@@ -623,18 +736,19 @@
                       reject(err);
                       return;
                     }
+                    addChecked('Create ApexClassMembers');
                     resolve(options[3]);
                   //createContainerAsyncRequest(containerId);
                 });
               } else {
+                addChecked('Create ApexClassMembers');
                 resolve(options[3])
               }
             });
           }
  
- 
           var createContainerAsyncRequest = function(containerId) {
-            createTimelineElement('Create Compilation Request')
+            createTimelineElement('Create Compilation Request');
             return new Promise(function(resolve,reject){
               conn.tooling.sobject('ContainerAsyncRequest').create({
                 IsCheckOnly: true,
@@ -645,6 +759,7 @@
                   reject(err);
                   return;
                 }
+                addChecked('Create Compilation Request');
                 resolve({"containerId":containerId,"id":res.id});
                 //pollContainer(containerId, res.id);
               });
@@ -670,6 +785,7 @@
                     return;
                   }
                   if (results[0].State !== 'Queued') {
+                    addChecked('Get Compilation Status');
                     resolve(options.containerId);
                   } else {
                     setTimeout(pollAsyncRequestStatus, 1000);
@@ -681,7 +797,7 @@
           }
  
           var deleteContainer = function(containerId) {
-            createTimelineElement('Delete Container')
+            createTimelineElement('Delete Container');
             return new Promise(function(resolve,reject){
               // Put the name here
               if(containerId){
@@ -690,9 +806,11 @@
                     reject(err);
                     return;
                   }
+                  addChecked('Delete Container');
                   resolve();
                 });
               } else {
+                addChecked('Delete Container');
                 resolve();
               }
             })
@@ -700,27 +818,48 @@
  
           ///Get IDs of the testClasses and runs the tests. Then refresh angular controller to display the results.
           var runTests = function() {
-            createTimelineElement('Run Tests')
-            return new Promise(function(resolve,reject){
-              var classIDs = testClasses.map(function(record){
-                return record.Id;
-              });
-              if(classIDs.length > 0){
+              createTimelineElement('Run Tests');
+              return new Promise(function(resolve,reject){
+                  var classIDs = testClasses.map(function(record){
+                      return record.Id;
+                  });
+                  //Before version 37
+                  /*if(classIDs.length > 0){
+                    debugger
                 conn.tooling.runTestsAsynchronous(classIDs,function(error,result){
                   if(error) {
                     reject(error);
                     return;
                   }
+                  addChecked('Run Tests');
                   resolve(result);
                 });
               } else {
-                resolve();
-              }
+                  addChecked('Run Tests');
+              	  resolve();
+              }*/
+                //Version 37 and more testLevel : RunLocalTests / RunAllTestsInOrg
+                var url = conn.tooling._baseUrl() + "/runTestsAsynchronous/";
+                var options = jQuery('input[name=options]:checked').val();
+                if(options == "all"){
+                    options = "RunAllTestsInOrg";
+                }
+                else{
+                    options = "RunLocalTests";
+                }
+                conn.requestPost(url, {"testLevel" : options}, undefined, function(error,result){
+                    if(error) {
+                        reject(error);
+                        return;
+                    }
+                    addChecked('Run Tests');
+                    resolve(result);
+                });
             })
           }
  
           var getAsyncTestStatus = function(ParentJobId){
-            createTimelineElement('Get AsyncTestStatus')
+            createTimelineElement('Get AsyncTestStatus');
             return new Promise(function(resolve,reject){
               if(ParentJobId) {
                 (function pollAsyncTestStatus(){
@@ -732,7 +871,7 @@
                     var PollAgain = false;
  
                     for(var i in result.records) {
-                      if(result.records[i].Status !== 'Completed'){
+                      if(result.records[i].Status !== 'Completed' && result.records[i].Status !== 'Failed'){
                         PollAgain = true;
                         break;
                       }
@@ -740,12 +879,14 @@
                     if(PollAgain) {
                       setTimeout(pollAsyncTestStatus, 1000);
                     } else {
-                      resolve(result);
+                        addChecked('Get AsyncTestStatus');
+                        resolve(result);
                     }
                   });
                 })();
               } else {
-                resolve();
+                  addChecked('Get AsyncTestStatus');
+                  resolve();
               }
             })
           }
@@ -762,7 +903,16 @@
           ////////START METHOD GLOBAL COVERAGE CHART////////
           var retrieveCoverage = function(){
             return new Promise(function(resolve,reject){
-              conn.tooling.query("SELECT NumLinesCovered, NumLinesUncovered, ApexClassOrTrigger.Name FROM ApexCodeCoverageAggregate WHERE ApexClassOrTrigger.Name != 'MetadataService' AND ApexClassOrTrigger.Name != 'Chathon'" , function(error, result) {
+                //var query = "SELECT NumLinesCovered, NumLinesUncovered, ApexClassOrTrigger.Name FROM ApexCodeCoverageAggregate WHERE ApexClassOrTrigger.Name != 'MetadataService' AND ApexClassOrTrigger.Name != 'Chathon'";
+                var query = "SELECT ApexClassOrTriggerId, ApexClassOrTrigger.Name, NumLinesCovered, NumLinesUncovered "
+                            + "FROM ApexCodeCoverageAggregate "
+                            + "WHERE ApexClassOrTriggerId != NULL AND ApexClassOrTrigger.Name != NULL "
+                            + "AND (NumLinesCovered > 0 OR NumLinesUncovered > 0) AND NumLinesCovered != NULL "
+                            + "AND NumLinesUncovered != NULL "
+                			+ (localStorage.filter !== undefined && localStorage.filter != '' ? ' AND (' + localStorage.filter + ')' : '')
+                			+ "ORDER BY ApexClassOrTrigger.Name";
+                //console.log(query);
+              conn.tooling.query(query , function(error, result) {
                 if (error) {
                   reject(error);
                   return;
@@ -776,17 +926,17 @@
                     'Coverage' : calculateCov(coverage.NumLinesCovered,coverage.NumLinesUncovered),
                     'Priority' : calculatePriority(coverage.NumLinesCovered,coverage.NumLinesUncovered)});
                 }
-                data.sort(sortClassPriority);
-                resolve(calculateGlobalCoverage(data));
+                data.sort(sortClassPriority); //default sorting
+                //resolve(calculateGlobalCoverage(data));
+                resolve();
               });
             })
           }
  
- 
-          var buildChart = function(orgCoverage) {
+          var buildChart = function() {
             return new Promise(function(resolve,reject){
-              var ctx = document.getElementById("myChart").getContext("2d");
-              var data = [{value: orgCoverage,
+                var ctx = document.getElementById("myChart").getContext("2d");
+                var data = [{value: orgCoverage,
                   color:"#46BFBD",
                   highlight: "#5AD3D1",
                   label: "Coverage Done"
@@ -802,24 +952,35 @@
               resolve();
             })
           }
- 
-          retrieveCoverage()
-          .then(buildChart)
-          .then(handleSuccess)
-          .catch(handleError);
- 
+          
+          refreshData = function(){
+              retrieveCoverage()
+              .then(getOrgCoverage)
+              .then(buildChart)
+              .then(handleSuccess)
+              .catch(handleError);
+            };
+            
+          if(localStorage.filter !== undefined){
+              jQuery('#customFilter').val(localStorage.filter); 
+          }
+          refreshData();
  
           jQuery('#reset-coverage').click(function() {
+              jQuery(".timeline").html('');
             jQuery('#loading').show();
             jQuery('#reset-coverage').prop('disabled', 'disabled');
+              toogleLoading();
             Promise.all([deleteTestResult(),selectApexCodeCoverage().then(deleteApexCodeCoverage),selectApexCodeCoverageAggregate().then(deleteApexCodeCoverageAggregate),createContainer(),getClassNames()])
             .then(createApexClassMember)
             .then(createContainerAsyncRequest)
             .then(getAsyncRequest)
             .then(function(containerId){return Promise.all([runTests().then(getAsyncTestStatus),deleteContainer(containerId)])})
             .then(retrieveCoverage)
+            .then(getOrgCoverage)
             .then(buildChart)
             .then(handleSuccess)
+            .then(toogleLoading)
             .catch(handleError);
           });
         }


### PR DESCRIPTION
 - change the global coverage for chart : getting the value from estimated org coverage
 - optimize running test call (since v37 can test all classes in my namespace or in all namespaces). Selection by radio button
 - add top filter, included in the server query. For example : ApexClassOrTrigger.Name != 'MetadataService' and (NOT ApexClassOrTrigger.Name like 'fflib%'). The last filter is stored in the localStorage and reuse on refresh
 - add number of classes displayed after filter applied
 - add check mark on timeline item when completed
 - add spinner (useful ?)